### PR TITLE
Add the ability to wait for all the channels to be closed before exiting the main thread

### DIFF
--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -32,6 +32,7 @@ type EventBus struct {
 	registered   map[eh.EventHandlerType]struct{}
 	registeredMu sync.RWMutex
 	errCh        chan Error
+	wg           sync.WaitGroup
 }
 
 // Error is an async error containing the error and the event.
@@ -83,6 +84,9 @@ func (b *EventBus) Errors() <-chan Error {
 
 // Handles all events coming in on the channel.
 func (b *EventBus) handle(m eh.EventMatcher, h eh.EventHandler, ch <-chan evt) {
+	b.wg.Add(1)
+	defer b.wg.Done()
+
 	for e := range ch {
 		if !m(e.event) {
 			continue
@@ -117,6 +121,16 @@ func (b *EventBus) channel(m eh.EventMatcher, h eh.EventHandler, observer bool) 
 		id = fmt.Sprintf("%s-%s", id, eh.NewUUID())
 	}
 	return b.group.channel(id)
+}
+
+// Close all the channels in the events bus group
+func (b *EventBus) Close() {
+	b.group.Close()
+}
+
+// Wait for all channels to close in the event bus group
+func (b *EventBus) Wait() {
+	b.wg.Wait()
 }
 
 // Group is a publishing group shared by multiple event busses locally, if needed.
@@ -160,5 +174,12 @@ func (g *Group) publish(ctx context.Context, event eh.Event) {
 		default:
 			// TODO: Maybe log here because queue is full.
 		}
+	}
+}
+
+// Close all the open channels
+func (g *Group) Close() {
+	for _, ch := range g.bus {
+		close(ch)
 	}
 }


### PR DESCRIPTION
# Summary
This is to solve an issue where the processing of some events wouldn't be complete when the main process exited

# How to test

1) Add an event handler (projector) and add a long task in the find method (example sleep for a few seconds)
2) Send a command immediately after the setup of the command & event buses.
3) See that the event handler didn't complete it's task before the main process exits

# Notes
This is only relevant if event horizon isn't used as a long running process. In our case we're running in AWS Lambda which make it very short lived
